### PR TITLE
Replacing Response by interface ResponseWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import (
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("ping", "Ping!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("ping", "Ping!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.Reply("pong")
 	})
 
@@ -76,7 +76,7 @@ func main() {
 		log.Println(err)
 	})
 
-	bot.Default(func(request *slacker.Request, response *slacker.Response) {
+	bot.Default(func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.Reply("Say what?")
 	})
 
@@ -102,7 +102,7 @@ import (
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("echo <word>", "Echo a word!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("echo <word>", "Echo a word!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		word := request.Param("word")
 		response.Reply(word)
 	})
@@ -130,7 +130,7 @@ import (
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("repeat <word> <number>", "Repeat a word a number of times!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("repeat <word> <number>", "Repeat a word a number of times!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		word := request.StringParam("word", "Hello!")
 		number := request.IntegerParam("number", 1)
 		for i := 0; i < number; i++ {
@@ -161,7 +161,7 @@ import (
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("test", "Tests something", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("test", "Tests something", func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.ReportError(errors.New("Oops!"))
 	})
 
@@ -188,7 +188,7 @@ import (
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("time", "Server time!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("time", "Server time!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.Typing()
 
 		time.Sleep(time.Second)
@@ -220,7 +220,7 @@ import (
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("upload <word>", "Upload a word!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("upload <word>", "Upload a word!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		word := request.Param("word")
 		channel := request.Event.Channel
 		bot.Client.UploadFile(slack.FileUploadParameters{Content: word, Channels: []string{channel}})

--- a/command.go
+++ b/command.go
@@ -6,7 +6,7 @@ import (
 )
 
 // NewBotCommand creates a new bot command object
-func NewBotCommand(usage string, description string, handler func(request *Request, response *Response)) *BotCommand {
+func NewBotCommand(usage string, description string, handler func(request *Request, response ResponseWriter)) *BotCommand {
 	command := commander.NewCommand(usage)
 	return &BotCommand{usage: usage, description: description, handler: handler, command: command}
 }
@@ -15,7 +15,7 @@ func NewBotCommand(usage string, description string, handler func(request *Reque
 type BotCommand struct {
 	usage       string
 	description string
-	handler     func(request *Request, response *Response)
+	handler     func(request *Request, response ResponseWriter)
 	command     *commander.Command
 }
 
@@ -25,6 +25,6 @@ func (c *BotCommand) Match(text string) (*proper.Properties, bool) {
 }
 
 // Execute executes the handler logic
-func (c *BotCommand) Execute(request *Request, response *Response) {
+func (c *BotCommand) Execute(request *Request, response ResponseWriter) {
 	c.handler(request, response)
 }

--- a/examples/example1.go
+++ b/examples/example1.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/shomali11/slacker"
 	"log"
+
+	"github.com/shomali11/slacker"
 )
 
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("ping", "Ping!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("ping", "Ping!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.Reply("pong")
 	})
 

--- a/examples/example2.go
+++ b/examples/example2.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/shomali11/slacker"
 	"log"
+
+	"github.com/shomali11/slacker"
 )
 
 func main() {
@@ -16,7 +17,7 @@ func main() {
 		log.Println(err)
 	})
 
-	bot.Default(func(request *slacker.Request, response *slacker.Response) {
+	bot.Default(func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.Reply("Say what?")
 	})
 

--- a/examples/example3.go
+++ b/examples/example3.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/shomali11/slacker"
 	"log"
+
+	"github.com/shomali11/slacker"
 )
 
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("echo <word>", "Echo a word!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("echo <word>", "Echo a word!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		word := request.Param("word")
 		response.Reply(word)
 	})

--- a/examples/example4.go
+++ b/examples/example4.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"github.com/shomali11/slacker"
 	"log"
+
+	"github.com/shomali11/slacker"
 )
 
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("repeat <word> <number>", "Repeat a word a number of times!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("repeat <word> <number>", "Repeat a word a number of times!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		word := request.StringParam("word", "Hello!")
 		number := request.IntegerParam("number", 1)
 		for i := 0; i < number; i++ {

--- a/examples/example5.go
+++ b/examples/example5.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"errors"
-	"github.com/shomali11/slacker"
 	"log"
+
+	"github.com/shomali11/slacker"
 )
 
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("test", "Tests something", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("test", "Tests something", func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.ReportError(errors.New("Oops!"))
 	})
 

--- a/examples/example6.go
+++ b/examples/example6.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	"github.com/shomali11/slacker"
 	"log"
 	"time"
+
+	"github.com/shomali11/slacker"
 )
 
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("time", "Server time!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("time", "Server time!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		response.Typing()
 
 		time.Sleep(time.Second)

--- a/examples/example7.go
+++ b/examples/example7.go
@@ -1,15 +1,16 @@
 package main
 
 import (
+	"log"
+
 	"github.com/nlopes/slack"
 	"github.com/shomali11/slacker"
-	"log"
 )
 
 func main() {
 	bot := slacker.NewClient("<YOUR SLACK BOT TOKEN>")
 
-	bot.Command("upload <word>", "Upload a word!", func(request *slacker.Request, response *slacker.Response) {
+	bot.Command("upload <word>", "Upload a word!", func(request *slacker.Request, response slacker.ResponseWriter) {
 		word := request.Param("word")
 		channel := request.Event.Channel
 		bot.Client.UploadFile(slack.FileUploadParameters{Content: word, Channels: []string{channel}})

--- a/response.go
+++ b/response.go
@@ -2,12 +2,20 @@ package slacker
 
 import (
 	"fmt"
+
 	"github.com/nlopes/slack"
 )
 
 const (
 	errorFormat = "*Error:* _%s_"
 )
+
+// A ResponseWriter interface is used to respond to an event
+type ResponseWriter interface {
+	Reply(text string)
+	ReportError(err error)
+	Typing()
+}
 
 // NewResponse creates a new response structure
 func NewResponse(channel string, rtm *slack.RTM) *Response {

--- a/slacker.go
+++ b/slacker.go
@@ -3,10 +3,11 @@ package slacker
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/nlopes/slack"
 	"github.com/shomali11/commander"
 	"github.com/shomali11/proper"
-	"strings"
 )
 
 const (
@@ -38,7 +39,7 @@ type Slacker struct {
 	botCommands    []*BotCommand
 	initHandler    func()
 	errorHandler   func(err string)
-	defaultHandler func(request *Request, response *Response)
+	defaultHandler func(request *Request, response ResponseWriter)
 }
 
 // Init handle the event when the bot is first connected
@@ -52,12 +53,12 @@ func (s *Slacker) Err(errorHandler func(err string)) {
 }
 
 // Default handle when none of the commands are matched
-func (s *Slacker) Default(defaultHandler func(request *Request, response *Response)) {
+func (s *Slacker) Default(defaultHandler func(request *Request, response ResponseWriter)) {
 	s.defaultHandler = defaultHandler
 }
 
 // Command define a new command and append it to the list of existing commands
-func (s *Slacker) Command(usage string, description string, handler func(request *Request, response *Response)) {
+func (s *Slacker) Command(usage string, description string, handler func(request *Request, response ResponseWriter)) {
 	s.botCommands = append(s.botCommands, NewBotCommand(usage, description, handler))
 }
 


### PR DESCRIPTION
⚠️  Breaking API change suggestion

Replacing the type Response by ResponseWriter lets
users wrap the response type with their own implementation.

Ex: adding logging for all outgoing messages in one central place.


````go
type CustomErrorWriter struct {
	slacker.ResponseWriter
}

func (l *CustomErrorWriter) ReportError(err error) {
	response := fmt.Sprintf("custom error format: %s", err)
	l.ResponseWriter.Reply(response)
}

func CustomError(f func(r *slacker.Request, w slacker.ResponseWriter)) func(r *slacker.Request, w slacker.ResponseWriter) {
	fn := func(r *slacker.Request, w slacker.ResponseWriter) {
		rw := &CustomErrorWriter{w}
		f(r, rw)
	}
	return fn
}

// Usage

bot.Command("ping", "Ping!", CustomError(func(request *slacker.Request, w slacker.ResponseWriter) {
	w.ReportError(errors.New("my error"))
}))

````

Let me know if you have any feedback on this PR.
