### PR TITLE
Add context

### DIFF
--- a/request.go
+++ b/request.go
@@ -1,6 +1,8 @@
 package slacker
 
 import (
+	"context"
+
 	"github.com/nlopes/slack"
 	"github.com/shomali11/proper"
 )
@@ -10,12 +12,13 @@ const (
 )
 
 // NewRequest creates a new Request structure
-func NewRequest(event *slack.MessageEvent, properties *proper.Properties) *Request {
-	return &Request{Event: event, properties: properties}
+func NewRequest(ctx context.Context, event *slack.MessageEvent, properties *proper.Properties) *Request {
+	return &Request{Context: ctx, Event: event, properties: properties}
 }
 
 // Request contains the Event received and parameters
 type Request struct {
+	Context    context.Context
 	Event      *slack.MessageEvent
 	properties *proper.Properties
 }


### PR DESCRIPTION
Example use:

````go

bot := slacker.New("secret-token", slacker.WithTimeout(5*time.Second))

bot.Command("ping", "Ping!", CustomError(func(request *slacker.Request, response slacker.ResponseWriter) {
		rand.Seed(time.Now().UTC().UnixNano())
		n := rand.Int63n(10) // wait up to 10 seconds
		t := time.After(time.Duration(n) * time.Second)
		select {
		case <-request.Ctx.Done():
			response.ReportError(errors.New("⚠️ Timed out"))
		case <-t:
			response.Reply(fmt.Sprintf("Waited %d seconds to say: pong!", n))
		}
	}))
````

I originally wanted to hide the `request.Ctx.Done():` from the command but couldn't find an elegant way to do it.

Let me know what you think.