### PR TITLE
Make BotCommand an interface. Have Slacker expose the list of commands.

### DIFF
--- a/command.go
+++ b/command.go
@@ -6,30 +6,50 @@ import (
 )
 
 // NewBotCommand creates a new bot command object
-func NewBotCommand(usage string, description string, handler func(request Request, response ResponseWriter)) *BotCommand {
+func NewBotCommand(usage string, description string, handler func(request Request, response ResponseWriter)) BotCommand {
 	command := commander.NewCommand(usage)
-	return &BotCommand{usage: usage, description: description, handler: handler, command: command}
+	return &botCommand{usage: usage, description: description, handler: handler, command: command}
 }
 
-// BotCommand structure contains the bot's command, description and handler
-type BotCommand struct {
+// botCommand structure contains the bot's command, description and handler
+type botCommand struct {
 	usage       string
 	description string
 	handler     func(request Request, response ResponseWriter)
 	command     *commander.Command
 }
 
+// BotCommand interface
+type BotCommand interface {
+	Usage() string
+	Description() string
+
+	Match(text string) (*proper.Properties, bool)
+	Tokenize() []*commander.Token
+	Execute(request Request, response ResponseWriter)
+}
+
+// Usage returns the command usage
+func (c *botCommand) Usage() string {
+	return c.usage
+}
+
+// Description returns the command description
+func (c *botCommand) Description() string {
+	return c.description
+}
+
 // Match determines whether the bot should respond based on the text received
-func (c *BotCommand) Match(text string) (*proper.Properties, bool) {
+func (c *botCommand) Match(text string) (*proper.Properties, bool) {
 	return c.command.Match(text)
 }
 
 // Tokenize returns the command format's tokens
-func (c *BotCommand) Tokenize() []*commander.Token {
+func (c *botCommand) Tokenize() []*commander.Token {
 	return c.command.Tokenize()
 }
 
 // Execute executes the handler logic
-func (c *BotCommand) Execute(request Request, response ResponseWriter) {
+func (c *botCommand) Execute(request Request, response ResponseWriter) {
 	c.handler(request, response)
 }

--- a/slacker.go
+++ b/slacker.go
@@ -38,12 +38,16 @@ func NewClient(token string) *Slacker {
 type Slacker struct {
 	client                *slack.Client
 	rtm                   *slack.RTM
-	botCommands           []*BotCommand
+	botCommands           []BotCommand
 	initHandler           func()
 	errorHandler          func(err string)
 	helpHandler           func(request Request, response ResponseWriter)
 	defaultMessageHandler func(request Request, response ResponseWriter)
 	defaultEventHandler   func(interface{})
+}
+
+func (s *Slacker) BotCommands() []BotCommand {
+	return s.botCommands
 }
 
 // Init handle the event when the bot is first connected
@@ -173,7 +177,7 @@ func (s *Slacker) defaultHelp(request Request, response ResponseWriter) {
 				helpMessage += fmt.Sprintf(boldMessageFormat, token.Word) + space
 			}
 		}
-		helpMessage += dash + space + fmt.Sprintf(italicMessageFormat, command.description) + newLine
+		helpMessage += dash + space + fmt.Sprintf(italicMessageFormat, command.Description()) + newLine
 	}
 	response.Reply(helpMessage)
 }
@@ -182,5 +186,5 @@ func (s *Slacker) prependHelpHandle() {
 	if s.helpHandler == nil {
 		s.helpHandler = s.defaultHelp
 	}
-	s.botCommands = append([]*BotCommand{NewBotCommand(helpCommand, helpCommand, s.helpHandler)}, s.botCommands...)
+	s.botCommands = append([]BotCommand{NewBotCommand(helpCommand, helpCommand, s.helpHandler)}, s.botCommands...)
 }


### PR DESCRIPTION
By making BotCommand an interface, we make it easier to mock test it.
Exposing the available commands register in Slacker, allows us to write
our own custom help function having access to the usage and description.