### PR TITLE
Pass the text to PostMessage as a MsgOption

### DIFF
--- a/response.go
+++ b/response.go
@@ -46,6 +46,7 @@ func (r *response) Reply(message string, options ...DefaultsOption) {
 
 	r.rtm.PostMessage(
 		r.channel,
+		slack.MsgOptionText(message, false),
 		slack.MsgOptionUser(r.rtm.GetInfo().User.ID),
 		slack.MsgOptionAsUser(true),
 		slack.MsgOptionAttachments(defaults.Attachments...),


### PR DESCRIPTION
Otherwise it will fail and return an error.

@shomali11 This was missing in https://github.com/shomali11/slacker/pull/29