### PR TITLE
Enable debugging output if envvar SLACKER_DEBUG is set

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -12,9 +12,17 @@ func WithAttachments(attachments []slack.Attachment) DefaultsOption {
 	}
 }
 
+// WithDebug sets message attachments
+func WithDebug(debug bool) DefaultsOption {
+	return func(defaults *Defaults) {
+		defaults.Debug = debug
+	}
+}
+
 // Defaults configuration
 type Defaults struct {
 	Attachments []slack.Attachment
+	Debug       bool
 }
 
 func newDefaults(options ...DefaultsOption) *Defaults {

--- a/slacker.go
+++ b/slacker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/nlopes/slack"
@@ -26,11 +25,12 @@ const (
 )
 
 // NewClient creates a new client using the Slack API
-func NewClient(token string) *Slacker {
+func NewClient(token string, options ...DefaultsOption) *Slacker {
+	defaults := newDefaults(options...)
+
 	client := slack.New(token)
-	if os.Getenv("SLACKER_DEBUG") != "" {
-		client.SetDebug(true)
-	}
+	client.SetDebug(defaults.Debug) // must be set _before_ NewRTM() call
+
 	slacker := &Slacker{
 		client: client,
 		rtm:    client.NewRTM(),

--- a/slacker.go
+++ b/slacker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/nlopes/slack"
@@ -27,6 +28,9 @@ const (
 // NewClient creates a new client using the Slack API
 func NewClient(token string) *Slacker {
 	client := slack.New(token)
+	if os.Getenv("SLACKER_DEBUG") != "" {
+		client.SetDebug(true)
+	}
 	slacker := &Slacker{
 		client: client,
 		rtm:    client.NewRTM(),


### PR DESCRIPTION
It's useful to see nlopes/slack debug output when debugging connection issues or developing a bot. Added ability to enable such messages via environment variable `SLACKER_DEBUG`.