### PR TITLE
context.CancelFunc now propogates immediately

### DIFF
--- a/slacker.go
+++ b/slacker.go
@@ -117,10 +117,10 @@ func (s *Slacker) Listen(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			s.rtm.Disconnect()
-			return nil // ctx.Err() was uninterprable because it has no specific type- It's not a problem for me to cancel the context
+			return ctx.Err()
 		case msg, ok := <-s.rtm.IncomingEvents:
 			if !ok {
-				return nil // TODO: not really sure if this should return an error
+				return nil
 			}
 			switch event := msg.Data.(type) {
 			case *slack.ConnectedEvent:


### PR DESCRIPTION
Changed control flow of slacker.Slacker.Listen() so that it doesn't
prioritize slack channel events > context events

Re: https://github.com/shomali11/slacker/issues/33

Not sure if this is the best way to shut down a slacker bot but that's what I'm using now. Welcome feedback.

Would appreciate comments on error returns- notice inline comments