### PR TITLE
Added getters to Slacker for members

### DIFF
--- a/slacker.go
+++ b/slacker.go
@@ -63,6 +63,16 @@ func (s *Slacker) BotCommands() []BotCommand {
 	return s.botCommands
 }
 
+// Client returns the internal slack.Client of Slacker struct
+func (s *Slacker) Client() *slack.Client {
+	return s.client
+}
+
+// RTM returns returns the internal slack.RTM of Slacker struct
+func (s *Slacker) RTM() *slack.RTM {
+	return s.rtm
+}
+
 // Init handle the event when the bot is first connected
 func (s *Slacker) Init(initHandler func()) {
 	s.initHandler = initHandler


### PR DESCRIPTION
Last one, I promise! Very simple.

**Purpose:**

Exposing _nlopes/slack_ members in the `slacker` structure allows us to create an arbitrary slack bot, and then use "slacker" as a command/control interface for it. E.g.: A slack bot that relays important logs in RTM w/o command, but can be fine-tuned by slacker commands.

**Implementation:**
Created Getter func's for said purpose