### PR TITLE
Add support for Block Kit

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -38,14 +38,23 @@ func WithAttachments(attachments []slack.Attachment) ReplyOption {
 	}
 }
 
+// WithBlocks sets message blocks
+func WithBlocks(blocks []slack.Block) ReplyOption {
+	return func(defaults *ReplyDefaults) {
+		defaults.Blocks = blocks
+	}
+}
+
 // ReplyDefaults configuration
 type ReplyDefaults struct {
 	Attachments []slack.Attachment
+	Blocks      []slack.Block
 }
 
 func newReplyDefaults(options ...ReplyOption) *ReplyDefaults {
 	config := &ReplyDefaults{
 		Attachments: []slack.Attachment{},
+		Blocks:      []slack.Block{},
 	}
 
 	for _, option := range options {

--- a/response.go
+++ b/response.go
@@ -50,6 +50,7 @@ func (r *response) Reply(message string, options ...ReplyOption) {
 		slack.MsgOptionUser(r.rtm.GetInfo().User.ID),
 		slack.MsgOptionAsUser(true),
 		slack.MsgOptionAttachments(defaults.Attachments...),
+		slack.MsgOptionBlocks(defaults.Blocks...)
 	)
 }
 


### PR DESCRIPTION
Extend Reply defaults to include Blocks and include these in the rtm.PostMessage.

Implements #46 

Signed-off-by: Philip Marc Schwartz <Philip.Schwartz1@T-Mobile.com>