### PR TITLE
Allow event handler to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ func contains(list []string, element string) bool {
 
 ## Example 14
 
-Adding handlers to when the bot is connected, encounters an error and a default for when none of the commands match
+Adding handlers to when the bot is connected, encounters an error and a fallback for when none of the commands match
 
 ```go
 package main
@@ -642,7 +642,7 @@ func main() {
 		response.Reply("Say what?")
 	})
 
-	bot.DefaultEvent(func(event interface{}) {
+	bot.FallbackEvent(func(event interface{}) {
 		fmt.Println(event)
 	})
 

--- a/defaults.go
+++ b/defaults.go
@@ -5,6 +5,13 @@ import "github.com/slack-go/slack"
 // ClientOption an option for client values
 type ClientOption func(*ClientDefaults)
 
+// WithEventHandler overwrites the default event handler.
+func WithEventHandler(h EventHandler) ClientOption {
+	return func(defaults *ClientDefaults) {
+		defaults.EventHandler = h
+	}
+}
+
 // WithDebug sets debug toggle
 func WithDebug(debug bool) ClientOption {
 	return func(defaults *ClientDefaults) {
@@ -14,12 +21,14 @@ func WithDebug(debug bool) ClientOption {
 
 // ClientDefaults configuration
 type ClientDefaults struct {
-	Debug bool
+	Debug        bool
+	EventHandler EventHandler
 }
 
 func newClientDefaults(options ...ClientOption) *ClientDefaults {
 	config := &ClientDefaults{
-		Debug: false,
+		Debug:        false,
+		EventHandler: DefaultEventHandler,
 	}
 
 	for _, option := range options {

--- a/examples/14/example14.go
+++ b/examples/14/example14.go
@@ -24,7 +24,7 @@ func main() {
 		response.Reply("Say what?")
 	})
 
-	bot.DefaultEvent(func(event interface{}) {
+	bot.FallbackEvent(func(event interface{}) {
 		fmt.Println(event)
 	})
 

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,49 @@
+package slacker
+
+import (
+	"context"
+	"errors"
+
+	"github.com/slack-go/slack"
+)
+
+// EventHandler handles an incoming RTM event.
+type EventHandler func(ctx context.Context, s *Slacker, msg slack.RTMEvent) error
+
+// DefaultEventHandler it the default event handler.
+func DefaultEventHandler(ctx context.Context, s *Slacker, msg slack.RTMEvent) error {
+	switch event := msg.Data.(type) {
+	case *slack.ConnectedEvent:
+		if s.initHandler == nil {
+			return nil
+		}
+		go s.initHandler()
+
+	case *slack.MessageEvent:
+		if s.isFromBot(event) {
+			return nil
+		}
+
+		if !s.isBotMentioned(event) && !s.isDirectMessage(event) {
+			return nil
+		}
+		go s.handleMessage(ctx, event)
+
+	case *slack.RTMError:
+		if s.errorHandler == nil {
+			return nil
+		}
+		go s.errorHandler(event.Error())
+
+	case *slack.InvalidAuthEvent:
+		return errors.New(invalidToken)
+
+	default:
+		if s.fallbackEventHandler == nil {
+			return nil
+		}
+		go s.fallbackEventHandler(event)
+	}
+
+	return nil
+}

--- a/slacker.go
+++ b/slacker.go
@@ -41,7 +41,7 @@ func NewClient(token string, options ...ClientOption) *Slacker {
 		rtm:               client.NewRTM(),
 		commandChannel:    make(chan *CommandEvent, 100),
 		unAuthorizedError: unAuthorizedError,
-		eventHandler:      DefaultEventHandler,
+		eventHandler:      defaults.EventHandler,
 	}
 	return slacker
 }


### PR DESCRIPTION
Example of usage:

```go

handler := func(ctx context.Context, s *slacker.Slacker, msg slack.RTMEvent) error {
	switch event := msg.Data.(type) {
		case *slack.MessageEvent:
			// do any special process, like filter messages by channel and process them.
	}
	return slacker.DefaultEventHandler(ctx,  s, msg)
}
bot := slacker..NewClient(token, slacker.WithEventHandler(handler))
```