### PR TITLE
Update nlopes/slack dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/shomali11/slacker
 
 require (
 	github.com/gorilla/websocket v1.4.0 // indirect
-	github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d
+	github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/shomali11/commander v0.0.0-20190312174449-57e7c4df59d6
 	github.com/shomali11/proper v0.0.0-20180607004733-233a9a872c30

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d h1:ziZZlaAi8gvHe87RUuDh9kSerJl1pJGIika2qzP1bfk=
 github.com/nlopes/slack v0.5.1-0.20190605211732-a05dfd3f167d/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
+github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249 h1:Pr5gZa2VcmktVwq0lyC39MsN5tz356vC/pQHKvq+QBo=
+github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
This update adds support for Slack's [rich text update](https://api.slack.com/changelog/2019-09-what-they-see-is-what-you-get-and-more-and-less). The crucial commit here is https://github.com/nlopes/slack/commit/c4750fe73d883a2b1edff13e0d2e09290512b405#diff-74e7523bcca0f2b33679f1a95e2c64ad which prevents the UnmarshalJSON from returning an error by skipping over any `rich_text` blocks.