### PR TITLE
Enabling reply in thread

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -45,16 +45,51 @@ func WithBlocks(blocks []slack.Block) ReplyOption {
 	}
 }
 
+// ThreadResponse specifies the reply to be inside a thread of the original message
+func ThreadResponse() ReplyOption {
+	return func(defaults *ReplyDefaults) {
+		defaults.ThreadResponse = true
+	}
+}
+
 // ReplyDefaults configuration
 type ReplyDefaults struct {
-	Attachments []slack.Attachment
-	Blocks      []slack.Block
+	Attachments    []slack.Attachment
+	Blocks         []slack.Block
+	ThreadResponse bool
 }
 
 func newReplyDefaults(options ...ReplyOption) *ReplyDefaults {
 	config := &ReplyDefaults{
-		Attachments: []slack.Attachment{},
-		Blocks:      []slack.Block{},
+		Attachments:    []slack.Attachment{},
+		Blocks:         []slack.Block{},
+		ThreadResponse: false,
+	}
+
+	for _, option := range options {
+		option(config)
+	}
+	return config
+}
+
+// ReportErrorOption an option for report error values
+type ReportErrorOption func(*ReportErrorDefaults)
+
+// ReportErrorDefaults configuration
+type ReportErrorDefaults struct {
+	ThreadResponse bool
+}
+
+// ErrorThreadResponse specifies the reply to be inside a thread of the original message
+func ErrorThreadResponse() ReportErrorOption {
+	return func(defaults *ReportErrorDefaults) {
+		defaults.ThreadResponse = true
+	}
+}
+
+func newReportErrorDefaults(options ...ReportErrorOption) *ReportErrorDefaults {
+	config := &ReportErrorDefaults{
+		ThreadResponse: false,
 	}
 
 	for _, option := range options {

--- a/defaults.go
+++ b/defaults.go
@@ -45,10 +45,10 @@ func WithBlocks(blocks []slack.Block) ReplyOption {
 	}
 }
 
-// ThreadResponse specifies the reply to be inside a thread of the original message
-func ThreadResponse() ReplyOption {
+// WithThreadReply specifies the reply to be inside a thread of the original message
+func WithThreadReply(useThread bool) ReplyOption {
 	return func(defaults *ReplyDefaults) {
-		defaults.ThreadResponse = true
+		defaults.ThreadResponse = useThread
 	}
 }
 
@@ -80,10 +80,10 @@ type ReportErrorDefaults struct {
 	ThreadResponse bool
 }
 
-// ErrorThreadResponse specifies the reply to be inside a thread of the original message
-func ErrorThreadResponse() ReportErrorOption {
+// WithThreadError specifies the reply to be inside a thread of the original message
+func WithThreadError(useThread bool) ReportErrorOption {
 	return func(defaults *ReportErrorDefaults) {
-		defaults.ThreadResponse = true
+		defaults.ThreadResponse = useThread
 	}
 }
 

--- a/examples/11/example11.go
+++ b/examples/11/example11.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/shomali11/slacker"
 	"github.com/slack-go/slack"
 )
@@ -39,30 +40,30 @@ func main() {
 }
 
 // NewCustomResponseWriter creates a new ResponseWriter structure
-func NewCustomResponseWriter(channel string, client *slack.Client, rtm *slack.RTM) slacker.ResponseWriter {
-	return &MyCustomResponseWriter{channel: channel, client: client, rtm: rtm}
+func NewCustomResponseWriter(event *slack.MessageEvent, client *slack.Client, rtm *slack.RTM) slacker.ResponseWriter {
+	return &MyCustomResponseWriter{event: event, client: client, rtm: rtm}
 }
 
 // MyCustomResponseWriter a custom response writer
 type MyCustomResponseWriter struct {
-	channel string
-	client  *slack.Client
-	rtm     *slack.RTM
+	event  *slack.MessageEvent
+	client *slack.Client
+	rtm    *slack.RTM
 }
 
 // ReportError sends back a formatted error message to the channel where we received the event from
-func (r *MyCustomResponseWriter) ReportError(err error) {
-	r.rtm.SendMessage(r.rtm.NewOutgoingMessage(fmt.Sprintf(errorFormat, err.Error()), r.channel))
+func (r *MyCustomResponseWriter) ReportError(err error, options ...slacker.ReportErrorOption) {
+	r.rtm.SendMessage(r.rtm.NewOutgoingMessage(fmt.Sprintf(errorFormat, err.Error()), r.event.Channel))
 }
 
 // Typing send a typing indicator
 func (r *MyCustomResponseWriter) Typing() {
-	r.rtm.SendMessage(r.rtm.NewTypingMessage(r.channel))
+	r.rtm.SendMessage(r.rtm.NewTypingMessage(r.event.Channel))
 }
 
 // Reply send a attachments to the current channel with a message
 func (r *MyCustomResponseWriter) Reply(message string, options ...slacker.ReplyOption) {
-	r.rtm.SendMessage(r.rtm.NewOutgoingMessage(message, r.channel))
+	r.rtm.SendMessage(r.rtm.NewOutgoingMessage(message, r.event.Channel))
 }
 
 // RTM returns the RTM client

--- a/response.go
+++ b/response.go
@@ -13,31 +13,47 @@ const (
 // A ResponseWriter interface is used to respond to an event
 type ResponseWriter interface {
 	Reply(text string, options ...ReplyOption)
+	ReplyInThread(text string, options ...ReplyOption)
 	ReportError(err error)
+	ReportErrorInThread(err error)
 	Typing()
+	TypingInThread()
 	RTM() *slack.RTM
 	Client() *slack.Client
 }
 
 // NewResponse creates a new response structure
-func NewResponse(channel string, client *slack.Client, rtm *slack.RTM) ResponseWriter {
-	return &response{channel: channel, client: client, rtm: rtm}
+func NewResponse(event *slack.MessageEvent, client *slack.Client, rtm *slack.RTM) ResponseWriter {
+	return &response{event: event, client: client, rtm: rtm}
 }
 
 type response struct {
-	channel string
-	client  *slack.Client
-	rtm     *slack.RTM
+	event  *slack.MessageEvent
+	client *slack.Client
+	rtm    *slack.RTM
 }
 
 // ReportError sends back a formatted error message to the channel where we received the event from
 func (r *response) ReportError(err error) {
-	r.rtm.SendMessage(r.rtm.NewOutgoingMessage(fmt.Sprintf(errorFormat, err.Error()), r.channel))
+	r.rtm.SendMessage(r.rtm.NewOutgoingMessage(fmt.Sprintf(errorFormat, err.Error()), r.event.Channel))
+}
+
+// ReportErrorInThread sends back a formatted error message to the channel where we received the event from inside a thread to the previous message
+func (r *response) ReportErrorInThread(err error) {
+	r.rtm.SendMessage(r.rtm.NewOutgoingMessage(fmt.Sprintf(errorFormat, err.Error()), r.event.Channel, slack.RTMsgOptionTS(r.event.EventTimestamp)))
+
 }
 
 // Typing send a typing indicator
 func (r *response) Typing() {
-	r.rtm.SendMessage(r.rtm.NewTypingMessage(r.channel))
+	r.rtm.SendMessage(r.rtm.NewTypingMessage(r.event.Channel))
+}
+
+// TypingInThread send a typing indicator in a thread
+func (r *response) TypingInThread() {
+	message := r.rtm.NewTypingMessage(r.event.Channel)
+	message.ThreadTimestamp = r.event.EventTimestamp
+	r.rtm.SendMessage(message)
 }
 
 // Reply send a attachments to the current channel with a message
@@ -45,12 +61,27 @@ func (r *response) Reply(message string, options ...ReplyOption) {
 	defaults := newReplyDefaults(options...)
 
 	r.rtm.PostMessage(
-		r.channel,
+		r.event.Channel,
 		slack.MsgOptionText(message, false),
 		slack.MsgOptionUser(r.rtm.GetInfo().User.ID),
 		slack.MsgOptionAsUser(true),
 		slack.MsgOptionAttachments(defaults.Attachments...),
 		slack.MsgOptionBlocks(defaults.Blocks...),
+	)
+}
+
+// ReplyInThread send a attachments to the current channel with a message in a thread to the previous message
+func (r *response) ReplyInThread(message string, options ...ReplyOption) {
+	defaults := newReplyDefaults(options...)
+
+	r.rtm.PostMessage(
+		r.event.Channel,
+		slack.MsgOptionText(message, false),
+		slack.MsgOptionUser(r.rtm.GetInfo().User.ID),
+		slack.MsgOptionAsUser(true),
+		slack.MsgOptionAttachments(defaults.Attachments...),
+		slack.MsgOptionBlocks(defaults.Blocks...),
+		slack.MsgOptionTS(r.event.EventTimestamp),
 	)
 }
 

--- a/slacker.go
+++ b/slacker.go
@@ -51,7 +51,7 @@ type Slacker struct {
 	rtm                   *slack.RTM
 	botCommands           []BotCommand
 	requestConstructor    func(ctx context.Context, event *slack.MessageEvent, properties *proper.Properties) Request
-	responseConstructor   func(channel string, client *slack.Client, rtm *slack.RTM) ResponseWriter
+	responseConstructor   func(event *slack.MessageEvent, client *slack.Client, rtm *slack.RTM) ResponseWriter
 	initHandler           func()
 	errorHandler          func(err string)
 	helpDefinition        *CommandDefinition
@@ -92,7 +92,7 @@ func (s *Slacker) CustomRequest(requestConstructor func(ctx context.Context, eve
 }
 
 // CustomResponse creates a new response writer
-func (s *Slacker) CustomResponse(responseConstructor func(channel string, client *slack.Client, rtm *slack.RTM) ResponseWriter) {
+func (s *Slacker) CustomResponse(responseConstructor func(event *slack.MessageEvent, client *slack.Client, rtm *slack.RTM) ResponseWriter) {
 	s.responseConstructor = responseConstructor
 }
 
@@ -208,7 +208,7 @@ func (s *Slacker) handleMessage(ctx context.Context, message *slack.MessageEvent
 		s.responseConstructor = NewResponse
 	}
 
-	response := s.responseConstructor(message.Channel, s.client, s.rtm)
+	response := s.responseConstructor(message, s.client, s.rtm)
 
 	for _, cmd := range s.botCommands {
 		parameters, isMatch := cmd.Match(message.Text)


### PR DESCRIPTION
As the timestamp is needed to reply in thread, made some changes to be able to have this optional methods in `ResponseWriter`

- Changed `ResponseWriter` interface to have replies methods with `InThread` version
- Changed contructor to receive the events instead of only the channel
- Adapted the whole code to comply to the new interface and constructor