### PR TITLE
propagate errors when posting a message

### DIFF
--- a/examples/11/example11.go
+++ b/examples/11/example11.go
@@ -63,8 +63,9 @@ func (r *MyCustomResponseWriter) Typing() {
 }
 
 // Reply send a attachments to the current channel with a message
-func (r *MyCustomResponseWriter) Reply(message string, options ...slacker.ReplyOption) {
+func (r *MyCustomResponseWriter) Reply(message string, options ...slacker.ReplyOption) error {
 	rtm := r.botCtx.RTM()
 	event := r.botCtx.Event()
 	rtm.SendMessage(rtm.NewOutgoingMessage(message, event.Channel))
+	return nil
 }


### PR DESCRIPTION
Posting messages to Slack can fail due to a variety of reason. For example, exceeding the maximum number of characters in a message. Currently, the `ResponseWriter` does not return any error that may have occurred using the `Reply` method. Because of this, it's possible that messages could not be sent and you may not notice.

This changes the `ResponseWriter` interface to return an `error` in the `Reply` method.

This change should not break usages of `rw.Reply` as it did not return anything before, but it is a breaking change because custom `ResponseWriter`s have to return an error now on reply.

Let me know if you think we should not be breaking the API to think of another possible solution.

Thank you!