### PR TITLE
Socket mode client with context

### DIFF
--- a/slacker.go
+++ b/slacker.go
@@ -206,7 +206,7 @@ func (s *Slacker) Listen(ctx context.Context) error {
 
 	// blocking call that handles listening for events and placing them in the
 	// Events channel as well as handling outgoing events.
-	return s.socketModeClient.Run()
+	return s.socketModeClient.RunContext(ctx)
 }
 
 func (s *Slacker) unsupportedEventReceived() {


### PR DESCRIPTION
Currently the `func (s *Slacker) Listen(ctx context.Context) error`  accepts a context but it is only used by the inner goroutine to stop the select loop.

When the context is cancelled, the inner goroutine stops but not the socketmode client.

Since the socketmode client has a `RunContext` method, using it will allow graceful shutdowns.
