### PR TITLE
add logger option

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -1,6 +1,10 @@
 package slacker
 
-import "github.com/slack-go/slack"
+import (
+	"log"
+
+	"github.com/slack-go/slack"
+)
 
 // ClientOption an option for client values
 type ClientOption func(*ClientDefaults)
@@ -12,14 +16,23 @@ func WithDebug(debug bool) ClientOption {
 	}
 }
 
+// WithLogger specifies the logger to be used
+func WithLogger(l logger) ClientOption {
+	return func(defaults *ClientDefaults) {
+		defaults.Logger = l
+	}
+}
+
 // ClientDefaults configuration
 type ClientDefaults struct {
-	Debug bool
+	Debug  bool
+	Logger logger
 }
 
 func newClientDefaults(options ...ClientOption) *ClientDefaults {
 	config := &ClientDefaults{
-		Debug: false,
+		Debug:  false,
+		Logger: log.Default(),
 	}
 
 	for _, option := range options {

--- a/examples/16/example16.go
+++ b/examples/16/example16.go
@@ -1,0 +1,36 @@
+// Disabling log example
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/shomali11/slacker"
+)
+
+func main() {
+	bot := slacker.NewClient(
+		os.Getenv("SLACK_BOT_TOKEN"),
+		os.Getenv("SLACK_APP_TOKEN"),
+		slacker.WithLogger(slacker.NullLogger),
+	)
+
+	definition := &slacker.CommandDefinition{
+		Description: "Ping!",
+		Example:     "ping",
+		Handler: func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
+			response.Reply("pong", slacker.WithThreadReply(true))
+		},
+	}
+
+	bot.Command("ping", definition)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,69 @@
+package slacker
+
+import "fmt"
+
+// logger is a logger interface compatible with both stdlib and some
+// 3rd party loggers. Since slack-go doesn't exposes this interface
+// it is redeclared here.
+type logger interface {
+	Output(int, string) error
+}
+
+//A default nullLogger instance
+var NullLogger = nullLogger{}
+
+// Declares a simple no op logger to use as default.
+type nullLogger struct{}
+
+func (n nullLogger) Output(int, string) error {
+	return nil
+}
+
+// ilogger represents the internal logging api we use.
+type ilogger interface {
+	logger
+	Print(...interface{})
+	Printf(string, ...interface{})
+	Println(...interface{})
+}
+
+type Debug interface {
+	Debug() bool
+
+	// Debugf print a formatted debug line.
+	Debugf(format string, v ...interface{})
+	// Debugln print a debug line.
+	Debugln(v ...interface{})
+}
+
+// internalLog implements the additional methods used by our internal logging.
+type internalLog struct {
+	logger
+}
+
+// Println replicates the behaviour of the standard logger.
+func (t internalLog) Println(v ...interface{}) {
+	t.Output(2, fmt.Sprintln(v...))
+}
+
+// Printf replicates the behaviour of the standard logger.
+func (t internalLog) Printf(format string, v ...interface{}) {
+	t.Output(2, fmt.Sprintf(format, v...))
+}
+
+// Print replicates the behaviour of the standard logger.
+func (t internalLog) Print(v ...interface{}) {
+	t.Output(2, fmt.Sprint(v...))
+}
+
+type discard struct{}
+
+func (t discard) Debug() bool {
+	return false
+}
+
+// Debugf print a formatted debug line.
+func (t discard) Debugf(format string, v ...interface{}) {}
+
+// Debugln print a debug line.
+func (t discard) Debugln(v ...interface{}) {}


### PR DESCRIPTION
While running `slacker.Listen(ctx)` the goroutine is using `fmt` to output logging information.
Since some people might want to disable logging or swapping the logger for any reason, this changes will allow it.

The `slack-go` library unfortunately doesn't expose its logging interfaces but `A little copying is better than a little dependency.` ;)

A `NullLogger` example is provided and usage can be seen on example16.