### PR TITLE
Remove app_mentions from manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ With both tokens in hand, you can now proceed with the examples below.
 
 Slack [App Manifests](https://api.slack.com/reference/manifests) make it easy to share a app configurations. We provide a [simple manifest](./examples/app_manifest/manifest.yml) that should work with all the examples provided below.
 
+The manifest provided will send all messages in channels your bot is in to the bot (including DMs) and not just ones that actually mention them in the message.
+
+If you wish to only have your bot respond to messages they are directly messaged in, you will need to add the `app_mentions:read` scope, and remove:
+
+- `im:history`       # single-person dm
+- `mpim:history`     # multi-person dm
+- `channels:history` # public channels
+- `groups:history`   # private channels
+
+You'll also need to adjust the event subscriptions, adding `app_mention` and removing:
+
+- `message.channels`
+- `message.groups`
+- `message.im`
+- `message.mpim`
+
 # Examples
 
 ## Example 1

--- a/examples/app_manifest/manifest.yml
+++ b/examples/app_manifest/manifest.yml
@@ -14,7 +14,6 @@ features:
 oauth_config:
   scopes:
     bot:
-      - app_mentions:read
       - channels:history
       - chat:write
       - groups:history
@@ -23,7 +22,6 @@ oauth_config:
 settings:
   event_subscriptions:
     bot_events:
-      - app_mention
       - message.channels
       - message.groups
       - message.im


### PR DESCRIPTION
The manifest we ship sets up both message.im and message.channel in
addition to app_mention, but if app_mention is included with either
message event types then in the case where an app_mention is in a dm
(message.im) or channel (message.channel) that the bot is in, the bot
will receive two events and respond twice (as was seen in #82).

While a user may want that for some reason, they would also need to
account for that in their command code. To be friendlier for users
attempting to get started, we'll remove the app_mention since message.im
and message.channel will send an event whether the bot is mentioned or
not as long as it is in the channel.