### PR TITLE
Add functionality to control handling of incoming bot events

### DIFF
--- a/bots.go
+++ b/bots.go
@@ -1,0 +1,21 @@
+package slacker
+
+// BotInteractionMode instruct the bot on how to handle incoming events that
+// originated from a bot.
+type BotInteractionMode int
+
+const (
+	// BotInteractionModeIgnoreAll instructs our bot to ignore any activity coming
+	// from other bots, including our self.
+	BotInteractionModeIgnoreAll BotInteractionMode = iota
+
+	// BotInteractionModeIgnoreApp will ignore any events that originate from a
+	// bot that is associated with the same App (ie. share the same App ID) as
+	// this bot. OAuth scope `user:read` is required for this mode.
+	BotInteractionModeIgnoreApp
+
+	// BotInteractionModeIgnoreNone will not ignore any bots, including our self.
+	// This can lead to bots "talking" to each other so care must be taken when
+	// selecting this option.
+	BotInteractionModeIgnoreNone
+)

--- a/context.go
+++ b/context.go
@@ -75,7 +75,8 @@ type MessageEvent struct {
 	// `app_mention` or `message`
 	Type string
 
-	// BotID holds the Slack User ID for our bot
+	// BotID of the bot that sent this message. If a bot did not send this
+	// message, this will be an empty string.
 	BotID string
 }
 

--- a/defaults.go
+++ b/defaults.go
@@ -12,14 +12,24 @@ func WithDebug(debug bool) ClientOption {
 	}
 }
 
+// WithBotInteractionMode instructs Slacker on how to handle message events coming from a
+// bot.
+func WithBotInteractionMode(mode BotInteractionMode) ClientOption {
+	return func(defaults *ClientDefaults) {
+		defaults.BotMode = mode
+	}
+}
+
 // ClientDefaults configuration
 type ClientDefaults struct {
-	Debug bool
+	Debug   bool
+	BotMode BotInteractionMode
 }
 
 func newClientDefaults(options ...ClientOption) *ClientDefaults {
 	config := &ClientDefaults{
-		Debug: false,
+		Debug:   false,
+		BotMode: BotInteractionModeIgnoreAll,
 	}
 
 	for _, option := range options {

--- a/examples/app_manifest/manifest.yml
+++ b/examples/app_manifest/manifest.yml
@@ -20,6 +20,7 @@ oauth_config:
       - groups:history
       - im:history
       - mpim:history
+      - users:read
 settings:
   event_subscriptions:
     bot_events:

--- a/slacker.go
+++ b/slacker.go
@@ -101,6 +101,7 @@ func (s *Slacker) Err(errorHandler func(err string)) {
 	s.errorHandler = errorHandler
 }
 
+// Interactive assigns an interactive event handler
 func (s *Slacker) Interactive(interactiveEventHandler func(*Slacker, *socketmode.Event, *slack.InteractionCallback)) {
 	s.interactiveEventHandler = interactiveEventHandler
 }


### PR DESCRIPTION
Adds functionality to control how Slacker responds to incoming events that originated from a bot. The current behavior is to ignore all events that come from a bot, and this behavior leaves that as the default while allowing for two other options: accepting all bot events, ignoring events that come from a bot with the same AppID as our current Slacker instance.

Resolves #84 