### PR TITLE
Add support for slash commands and interactive msg

### DIFF
--- a/command.go
+++ b/command.go
@@ -3,14 +3,18 @@ package slacker
 import (
 	"github.com/shomali11/commander"
 	"github.com/shomali11/proper"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
 )
 
 // CommandDefinition structure contains definition of the bot command
 type CommandDefinition struct {
 	Description       string
 	Example           string
+	BlockID           string
 	AuthorizationFunc func(botCtx BotContext, request Request) bool
 	Handler           func(botCtx BotContext, request Request, response ResponseWriter)
+	Interactive       func(*Slacker, *socketmode.Event, *slack.InteractionCallback, *socketmode.Request)
 }
 
 // NewBotCommand creates a new bot command object
@@ -31,6 +35,7 @@ type BotCommand interface {
 	Match(text string) (*proper.Properties, bool)
 	Tokenize() []*commander.Token
 	Execute(botCtx BotContext, request Request, response ResponseWriter)
+	Interactive(*Slacker, *socketmode.Event, *slack.InteractionCallback, *socketmode.Request)
 }
 
 // botCommand structure contains the bot's command, description and handler
@@ -66,4 +71,12 @@ func (c *botCommand) Execute(botCtx BotContext, request Request, response Respon
 		return
 	}
 	c.definition.Handler(botCtx, request, response)
+}
+
+// Interactive executes the interactive logic
+func (c *botCommand) Interactive(slacker *Slacker, evt *socketmode.Event, callback *slack.InteractionCallback, req *socketmode.Request) {
+	if c.definition == nil || c.definition.Interactive == nil {
+		return
+	}
+	c.definition.Interactive(slacker, evt, callback, req)
 }

--- a/context.go
+++ b/context.go
@@ -56,13 +56,13 @@ type MessageEvent struct {
 	Channel string
 
 	// ChannelName where the message was sent
-	ChannelName func() string
+	ChannelName string
 
 	// User ID of the sender
 	User string
 
 	// UserName of the the sender
-	UserName func() string
+	UserName string
 
 	// Text is the unalterted text of the message, as returned by Slack
 	Text string

--- a/context.go
+++ b/context.go
@@ -55,8 +55,14 @@ type MessageEvent struct {
 	// Channel ID where the message was sent
 	Channel string
 
+	// ChannelName where the message was sent
+	ChannelName func() string
+
 	// User ID of the sender
 	User string
+
+	// UserName of the the sender
+	UserName func() string
 
 	// Text is the unalterted text of the message, as returned by Slack
 	Text string

--- a/examples/18/example18.go
+++ b/examples/18/example18.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/shomali11/slacker"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/socketmode"
+)
+
+func slackerCmd(actionID string) func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
+	return func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
+		happyBtn := slack.NewButtonBlockElement("happy", "true", slack.NewTextBlockObject("plain_text", "Happy 🙂", true, false))
+		happyBtn.Style = "primary"
+		sadBtn := slack.NewButtonBlockElement("sad", "false", slack.NewTextBlockObject("plain_text", "Sad ☹️", true, false))
+		sadBtn.Style = "danger"
+
+		err := response.Reply("", slacker.WithBlocks([]slack.Block{
+			slack.NewSectionBlock(slack.NewTextBlockObject(slack.PlainTextType, "What is your mood today?", true, false), nil, nil),
+			slack.NewActionBlock(actionID, happyBtn, sadBtn),
+		}))
+
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+}
+
+func slackerInteractive(s *slacker.Slacker, e *socketmode.Event, callback *slack.InteractionCallback, request *socketmode.Request) {
+	text := ""
+	action := callback.ActionCallback.BlockActions[0]
+	switch action.ActionID {
+	case "happy":
+		text = "I'm happy to hear you are happy!"
+	case "sad":
+		text = "I'm sorry to hear you are sad."
+	default:
+		text = "I don't understand your mood..."
+	}
+
+	_, _, _ = s.Client().PostMessage(callback.Channel.ID, slack.MsgOptionText(text, false),
+		slack.MsgOptionReplaceOriginal(callback.ResponseURL))
+}
+
+func main() {
+	bot := slacker.NewClient(os.Getenv("SLACK_BOT_TOKEN"), os.Getenv("SLACK_APP_TOKEN"))
+	bot.Command("slacker-cmd", &slacker.CommandDefinition{
+		BlockID:     "slacker_cmd",
+		Handler:     slackerCmd("slacker_cmd"),
+		Interactive: slackerInteractive,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/slacker.go
+++ b/slacker.go
@@ -210,7 +210,7 @@ func (s *Slacker) Listen(ctx context.Context) error {
 						fmt.Printf("Ignored %+v\n", evt)
 						continue
 					}
-
+					s.socketModeClient.Ack(*evt.Request)
 					go s.handleMessageEvent(ctx, &callback, evt.Request)
 				case socketmode.EventTypeInteractive:
 					callback, ok := evt.Data.(slack.InteractionCallback)

--- a/slacker.go
+++ b/slacker.go
@@ -330,7 +330,7 @@ func (s *Slacker) handleMessageEvent(ctx context.Context, evt interface{}, req *
 				if err.Error() == "missing_scope" {
 					fmt.Println("unable to determine if bot response is from me -- please add users:read scope to your app")
 				} else {
-					fmt.Printf("unable to get bot that sent message information: %v", err)
+					fmt.Printf("unable to get bot that sent message information: %v\n", err)
 				}
 				return
 			}
@@ -383,7 +383,7 @@ func (s *Slacker) handleMessageEvent(ctx context.Context, evt interface{}, req *
 func getChannelName(slacker *Slacker, channelID string) string {
 	channel, err := slacker.client.GetConversationInfo(channelID, true)
 	if err != nil {
-		fmt.Printf("unable to get channel info for %s: %v", channelID, err)
+		fmt.Printf("unable to get channel info for %s: %v\n", channelID, err)
 		return channelID
 	}
 	return channel.Name
@@ -392,7 +392,7 @@ func getChannelName(slacker *Slacker, channelID string) string {
 func getUserName(slacker *Slacker, userID string) string {
 	user, err := slacker.client.GetUserInfo(userID)
 	if err != nil {
-		fmt.Printf("unable to get user info for %s: %v", userID, err)
+		fmt.Printf("unable to get user info for %s: %v\n", userID, err)
 		return userID
 	}
 	return user.Name


### PR DESCRIPTION
Add support for slash commands within CommandDefinition.

Add support for interactive events as part of the CommandDefinition.

```golang

func wasArticleUseFulCmd(actionId string) func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
	return func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
        ....
        }
}

func wasArticleUseFulInteractive(s *slacker.Slacker, e *socketmode.Event, callback *slack.InteractionCallback, request *socketmode.Request) {
...
}

func main() {
  bot := slacker.NewClient(....)
  bot.Command("was-this-article-useful", &slacker.CommandDefinition{
		  BlockID:     "was_article_useful",
		  Handler:     wasArticleUseFulCmd("was_article_useful"),
		  Interactive: wasArticleUseFulInteractive,
	  })
}
```