### PR TITLE
Fix code formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ func main() {
 
 Override the default event input cleaning function (to sanitize the messages received by Slacker)
 
-```
+```go
 package main
 
 import (


### PR DESCRIPTION
The README.md is missing of go language formatting in the Example 17 block