### PR TITLE
Add ability to define a default inner event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ func contains(list []string, element string) bool {
 
 ## Example 13
 
-Adding handlers to when the bot is connected, encounters an error and a default for when none of the commands match
+Adding handlers to when the bot is connected, encounters an error and a default for when none of the commands match, adding default inner event handler when event type isn't message or app_mention
 
 ```go
 package main
@@ -674,6 +674,7 @@ import (
 	"fmt"
 
 	"github.com/shomali11/slacker"
+	"github.com/slack-go/slack/socketmode"
 )
 
 func main() {
@@ -693,6 +694,10 @@ func main() {
 
 	bot.DefaultEvent(func(event interface{}) {
 		fmt.Println(event)
+	})
+	
+	bot.DefaultInnerEvent(func(ctx context.Context, evt interface{}, request *socketmode.Request) {
+		fmt.Printf("Handling inner event: %s", evt)
 	})
 
 	definition := &slacker.CommandDefinition{

--- a/examples/13/example13.go
+++ b/examples/13/example13.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/shomali11/slacker"
+	"github.com/slack-go/slack/socketmode"
 )
 
 func main() {
@@ -27,6 +28,10 @@ func main() {
 
 	bot.DefaultEvent(func(event interface{}) {
 		fmt.Println(event)
+	})
+
+	bot.DefaultInnerEvent(func(ctx context.Context, evt interface{}, request *socketmode.Request) {
+		fmt.Printf("Handling inner event: %s", evt)
 	})
 
 	definition := &slacker.CommandDefinition{

--- a/slacker.go
+++ b/slacker.go
@@ -77,7 +77,7 @@ type Slacker struct {
 	helpDefinition           *CommandDefinition
 	defaultMessageHandler    func(botCtx BotContext, request Request, response ResponseWriter)
 	defaultEventHandler      func(interface{})
-	defaultInnerEventHandler func(interface{})
+	defaultInnerEventHandler func(ctx context.Context, evt interface{}, request *socketmode.Request)
 	errUnauthorized          error
 	commandChannel           chan *CommandEvent
 	appID                    string
@@ -151,7 +151,7 @@ func (s *Slacker) DefaultEvent(defaultEventHandler func(interface{})) {
 }
 
 // DefaultInnerEvent handle events when an unknown inner event is seen
-func (s *Slacker) DefaultInnerEvent(defaultInnerEventHandler func(interface{})) {
+func (s *Slacker) DefaultInnerEvent(defaultInnerEventHandler func(ctx context.Context, evt interface{}, request *socketmode.Request)) {
 	s.defaultInnerEventHandler = defaultInnerEventHandler
 }
 
@@ -220,7 +220,7 @@ func (s *Slacker) Listen(ctx context.Context) error {
 
 					default:
 						if s.defaultInnerEventHandler != nil {
-							s.defaultInnerEventHandler(evt)
+							s.defaultInnerEventHandler(ctx, ev.InnerEvent.Data, evt.Request)
 						} else {
 							fmt.Printf("unsupported inner event: %+v\n", ev.InnerEvent.Type)
 						}

--- a/slacker.go
+++ b/slacker.go
@@ -64,24 +64,25 @@ func NewClient(botToken, appToken string, options ...ClientOption) *Slacker {
 
 // Slacker contains the Slack API, botCommands, and handlers
 type Slacker struct {
-	client                  *slack.Client
-	socketModeClient        *socketmode.Client
-	botCommands             []BotCommand
-	botContextConstructor   func(ctx context.Context, api *slack.Client, client *socketmode.Client, evt *MessageEvent) BotContext
-	commandConstructor      func(usage string, definition *CommandDefinition) BotCommand
-	requestConstructor      func(botCtx BotContext, properties *proper.Properties) Request
-	responseConstructor     func(botCtx BotContext) ResponseWriter
-	initHandler             func()
-	errorHandler            func(err string)
-	interactiveEventHandler func(*Slacker, *socketmode.Event, *slack.InteractionCallback)
-	helpDefinition          *CommandDefinition
-	defaultMessageHandler   func(botCtx BotContext, request Request, response ResponseWriter)
-	defaultEventHandler     func(interface{})
-	errUnauthorized         error
-	commandChannel          chan *CommandEvent
-	appID                   string
-	botInteractionMode      BotInteractionMode
-	cleanEventInput         func(in string) string
+	client                   *slack.Client
+	socketModeClient         *socketmode.Client
+	botCommands              []BotCommand
+	botContextConstructor    func(ctx context.Context, api *slack.Client, client *socketmode.Client, evt *MessageEvent) BotContext
+	commandConstructor       func(usage string, definition *CommandDefinition) BotCommand
+	requestConstructor       func(botCtx BotContext, properties *proper.Properties) Request
+	responseConstructor      func(botCtx BotContext) ResponseWriter
+	initHandler              func()
+	errorHandler             func(err string)
+	interactiveEventHandler  func(*Slacker, *socketmode.Event, *slack.InteractionCallback)
+	helpDefinition           *CommandDefinition
+	defaultMessageHandler    func(botCtx BotContext, request Request, response ResponseWriter)
+	defaultEventHandler      func(interface{})
+	defaultInnerEventHandler func(interface{})
+	errUnauthorized          error
+	commandChannel           chan *CommandEvent
+	appID                    string
+	botInteractionMode       BotInteractionMode
+	cleanEventInput          func(in string) string
 }
 
 // BotCommands returns Bot Commands
@@ -149,6 +150,11 @@ func (s *Slacker) DefaultEvent(defaultEventHandler func(interface{})) {
 	s.defaultEventHandler = defaultEventHandler
 }
 
+// DefaultInnerEvent handle events when an unknown inner event is seen
+func (s *Slacker) DefaultInnerEvent(defaultInnerEventHandler func(interface{})) {
+	s.defaultInnerEventHandler = defaultInnerEventHandler
+}
+
 // UnAuthorizedError error message
 func (s *Slacker) UnAuthorizedError(errUnauthorized error) {
 	s.errUnauthorized = errUnauthorized
@@ -213,7 +219,11 @@ func (s *Slacker) Listen(ctx context.Context) error {
 						go s.handleMessageEvent(ctx, ev.InnerEvent.Data, nil)
 
 					default:
-						fmt.Printf("unsupported inner event: %+v\n", ev.InnerEvent.Type)
+						if s.defaultInnerEventHandler != nil {
+							s.defaultInnerEventHandler(evt)
+						} else {
+							fmt.Printf("unsupported inner event: %+v\n", ev.InnerEvent.Type)
+						}
 					}
 
 					s.socketModeClient.Ack(*evt.Request)


### PR DESCRIPTION
This feature will allow users to define a custom default inner event handler, such as handlers for events like:
- member_joined_channel
- member_left_channel
- group_left
- group_deleted
etc...

This would make the world of difference for some tooling we're building that we're hoping to use Slacker for

https://github.com/shomali11/slacker/issues/112