### PR TITLE
Update slack-go to latest available, fix getChannelName

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.14
 require (
 	github.com/shomali11/commander v0.0.0-20220716022157-b5248c76541a
 	github.com/shomali11/proper v0.0.0-20180607004733-233a9a872c30
-	github.com/slack-go/slack v0.11.2
+	github.com/slack-go/slack v0.12.1
 	github.com/stretchr/testify v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/shomali11/commander v0.0.0-20220716022157-b5248c76541a h1:NCmAZOmyqKw
 github.com/shomali11/commander v0.0.0-20220716022157-b5248c76541a/go.mod h1:bYyJw/Aj9fK+qoFmRbPJeWsDgq7WGO8f/Qof95qPug4=
 github.com/shomali11/proper v0.0.0-20180607004733-233a9a872c30 h1:56awf1OXG6Jc2Pk1saojpCzpzkoBvlqecCyNLY+wwkc=
 github.com/shomali11/proper v0.0.0-20180607004733-233a9a872c30/go.mod h1:O723XwIZBX3FR45rBic/Eyp/DKo/YtchYFURzpUWY2c=
-github.com/slack-go/slack v0.11.2 h1:IWl90Rk+jqPEVyiBytH27CSN/TFAg2vuDDfoPRog/nc=
-github.com/slack-go/slack v0.11.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
+github.com/slack-go/slack v0.12.1 h1:X97b9g2hnITDtNsNe5GkGx6O2/Sz/uC20ejRZN6QxOw=
+github.com/slack-go/slack v0.12.1/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/slacker.go
+++ b/slacker.go
@@ -415,7 +415,10 @@ func (s *Slacker) handleMessageEvent(ctx context.Context, evt interface{}, req *
 }
 
 func getChannelName(slacker *Slacker, channelID string) string {
-	channel, err := slacker.client.GetConversationInfo(channelID, true)
+	channel, err := slacker.client.GetConversationInfo(&slack.GetConversationInfoInput{
+		ChannelID:         channelID,
+		IncludeLocale:     false,
+		IncludeNumMembers: false})
 	if err != nil {
 		fmt.Printf("unable to get channel info for %s: %v\n", channelID, err)
 		return channelID


### PR DESCRIPTION
Updated slack-go to latest available, fix getChannelName after slack-go update.