### PR TITLE
Add Client config option to let the slack API URL be set

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -5,6 +5,13 @@ import "github.com/slack-go/slack"
 // ClientOption an option for client values
 type ClientOption func(*ClientDefaults)
 
+// WithAPIURL sets the API URL (for testing)
+func WithAPIURL(url string) ClientOption {
+	return func(defaults *ClientDefaults) {
+		defaults.APIURL = url
+	}
+}
+
 // WithDebug sets debug toggle
 func WithDebug(debug bool) ClientOption {
 	return func(defaults *ClientDefaults) {
@@ -21,12 +28,14 @@ func WithBotInteractionMode(mode BotInteractionMode) ClientOption {
 
 // ClientDefaults configuration
 type ClientDefaults struct {
+	APIURL  string
 	Debug   bool
 	BotMode BotInteractionMode
 }
 
 func newClientDefaults(options ...ClientOption) *ClientDefaults {
 	config := &ClientDefaults{
+		APIURL:  "", // Empty string will not override default from slack package
 		Debug:   false,
 		BotMode: BotInteractionModeIgnoreAll,
 	}

--- a/slacker.go
+++ b/slacker.go
@@ -42,10 +42,18 @@ func defaultCleanEventInput(msg string) string {
 func NewClient(botToken, appToken string, options ...ClientOption) *Slacker {
 	defaults := newClientDefaults(options...)
 
-	api := slack.New(
-		botToken,
+	slackOpts := []slack.Option{
 		slack.OptionDebug(defaults.Debug),
 		slack.OptionAppLevelToken(appToken),
+	}
+
+	if defaults.APIURL != "" {
+		slackOpts = append(slackOpts, slack.OptionAPIURL(defaults.APIURL))
+	}
+
+	api := slack.New(
+		botToken,
+		slackOpts...,
 	)
 
 	socketModeClient := socketmode.New(


### PR DESCRIPTION
This PR adds `WithAPIURL` as a `ClientOption` when constructing the client. This allows one to set the URL to the Slack API. While this is not necessary for real-life connections, allowing this override permits unit testing with `httptest` and the testing frameworks in <https://github.com/slack-go/slack/tree/master/slacktest>.

I refactored the initialization in `slacker.go` a bit so that we only actually set the option on the Slack client if we've defined a URL. I could have hard-coded the Slack API URL as a default and that would probably work great as well. However, I didn't want to make any changes (even under the hood) for the vast majority of users that won't call this option, and implementing it this way makes this change a no-op for everyone else.