### PR TITLE
fix: Use log package for logging

### DIFF
--- a/message_event.go
+++ b/message_event.go
@@ -128,7 +128,7 @@ func getChannel(slacker *Slacker, channelID string) *slack.Channel {
 		IncludeLocale:     false,
 		IncludeNumMembers: false})
 	if err != nil {
-		fmt.Printf("unable to get channel info for %s: %v\n", channelID, err)
+		slacker.logf("unable to get channel info for %s: %v\n", channelID, err)
 		return nil
 	}
 	return channel
@@ -141,7 +141,7 @@ func getUserProfile(slacker *Slacker, userID string) *slack.UserProfile {
 
 	user, err := slacker.apiClient.GetUserInfo(userID)
 	if err != nil {
-		fmt.Printf("unable to get user info for %s: %v\n", userID, err)
+		slacker.logf("unable to get user info for %s: %v\n", userID, err)
 		return nil
 	}
 	return &user.Profile

--- a/response.go
+++ b/response.go
@@ -2,6 +2,7 @@ package slacker
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/slack-go/slack"
 )
@@ -43,7 +44,7 @@ func (r *response) ReportError(err error, options ...ReportErrorOption) {
 
 	_, _, err = apiClient.PostMessage(event.ChannelID, opts...)
 	if err != nil {
-		fmt.Printf("failed posting message: %v\n", err)
+		log.Printf("failed posting message: %v\n", err)
 	}
 }
 


### PR DESCRIPTION
Using the `log` package ensures that timestamps are emitted with our log entries, and the format matches the logging behavior of the slack-go library when debugging is enabled.

Certain log entries, such as ignoring unsupported events, are now gated by whether or not debugging has been enabled.

Closes #131