### PR TITLE
Project maintenance updates

### DIFF
--- a/.git-czrc.json
+++ b/.git-czrc.json
@@ -1,0 +1,55 @@
+{
+	"message": {
+		"items": [
+			{
+				"name": "type",
+				"desc": "Select the type of change that you're committing:",
+				"form": "select",
+				"options": [
+					{ "name": "feat", "desc": "feat: A new feature" },
+					{ "name": "fix", "desc": "fix: A bug fix" },
+					{ "name": "docs", "desc": "docs: Documentation only changes" },
+					{
+					  "name": "refactor",
+					  "desc": "refactor: A code change that neither fixes a bug nor adds a feature"
+					},
+					{ "name": "test", "desc": "test: Adding missing tests" },
+					{
+					  "name": "chore",
+					  "desc":
+						"chore: Changes to the build process or auxiliary tools\n            and libraries such as documentation generation"
+					},
+					{ "name": "revert", "desc": "revert: Revert to a commit" },
+					{ "name": "WIP", "desc": "WIP: Work in progress" }
+				],
+				"required": true
+			},
+			{
+				"name": "scope",
+				"desc": "Scope. Could be anything specifying place of the commit change (users, db, poll):",
+				"form": "input"
+			},
+			{
+				"name": "subject",
+				"desc": "Subject. Concise description of the changes. Imperative, lower case and no final dot:",
+				"form": "input",
+				"required": true
+			},
+			{
+				"name": "body",
+				"desc": "Body. Motivation for the change and contrast this with previous behavior:",
+				"form": "multiline"
+			},
+			{
+				"name": "footer",
+				"desc": "Footer. Information about Breaking Changes and reference issues that this commit closes:",
+				"form": "multiline"
+			}
+		],
+		"template": "{{.type}}{{with .scope}}({{.}}){{end}}: {{.subject}}{{with .body}}\n\n{{.}}{{end}}{{with .footer}}\n\n{{.}}{{end}}"
+	}
+}
+
+
+
+

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -1,0 +1,43 @@
+name: 'Commit Message Check'
+on:
+  pull_request: {}
+  pull_request_target: {}
+  push:
+    branches:
+      - master
+      - 'releases/*'
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Subject Prefix
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '(fix|feat|chore|docs|test|refactor|revert|test)(\[[^]]+\])?: .*$'
+          flags: 'gm'
+          error: >-
+            Your first line is missing a valid subject prefix. See Commit
+            Messages section of CONTRIBUTING doc
+          checkAllCommitMessages: 'true'
+          excludeTitle: 'true'
+          excludeDescription: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check Line Length
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^(?![^#].{74})'
+          error: 'The maximum line length of 74 characters is exceeded.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+
+# Maybe in the future?
+#      - name: Check for Resolves / Fixes
+#        uses: gsactions/commit-message-checker@v2
+#        with:
+#          pattern: '^.+(Resolves|Fixes): \#[0-9]+$'
+#          error: 'You need at least one "Resolves|Fixes: #<issue number>" line.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,3 +82,33 @@ This section guides you through making a successful pull request.
 
 * Someone will review your PR and ensure it meets these guidelines. If it does
   not, we will ask you to fix the identified issues.
+
+### Commit Messages
+
+Commit subjects should begin with the following prefix `<type>:`, where type is
+one of the following change types:
+
+- `feat` adds a new feature or expands upon existing behavior
+- `fix` for changes that resolve an error in our code
+- `docs` for documentation updates
+- `chore` for changes related to project maintenance, such as github actions or linter configurations.
+- `revert` for a commit that reverts another commit
+- `test` for adding missing tests
+
+When multiple change types are present (ie. a new feature is created and as a result fixes a bug), you should use `feat`.
+
+If a change addresses one or more issues, be sure and include `Closes #1, #2,
+...` as a dedicated line at the end of your commit body.
+
+An example commit may look like:
+
+```
+feat: Add support for a custom command channel size
+
+Create an additional functional option `WithCommandChanSize(int)` that
+may be passed into `NewClient(...)` that lets the user specify the
+size of the channel used to hold incoming commands to be processed. This
+may be useful to expand for high-volume bots.
+
+Closes #319
+```

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,27 +1,50 @@
 Docs for slacker maintainers
 
+## Versioning
+
+Version numbers adhere to go [module versioning
+numbering](https://go.dev/doc/modules/version-numbers).
+
+Use the following criteria to identify which component of the version to change:
+
+- If a breaking change is made, the major version must be incremented
+- If any features are added, the minor version should be incremented
+- If only fixes are added, the patch version should be incremented
+- If no code changes are made, no version change should be made
+
+When updating the major version we must also update our [go.mod](./go.mod)
+module path to reflect this. For example the version 2.x.x module path should
+end with `/v2`.
+
 ## Releases
 
-Releases of Slacker are handled by [goreleaser](https://goreleaser.com) and
-Github actions. Simply tagging a release with a semver compatible version tag
-(ie. vX.Y.Z) and pushing the tag will trigger a Github action to generate a
-release. See the goreleaser [config](.goreleaser.yaml) and Github
-[workflow](.github/workflows/.goreleaser.yaml) files.
+Once all changes are merged to the master branch, a new release can be created
+by performing the following steps:
+
+- Identify new version number, `ie. v1.2.3`
+- Use [golang.org/x/exp/cmd/gorelease](https://pkg.go.dev/golang.org/x/exp/cmd/gorelease) to ensure version is acceptable
+    - If issues are identified, either fix the issues or change the target version
+    - Example: `gorelease -base=<previous> -version=<new>`
+- Tag commit with new version
+- Push tag upstream
+
+Once pushed, the [goreleaser](./.github/workflows/goreleaser.yaml) workflow is
+triggered to create a new GitHub release from this tag along with a changelog
+since the previous release.
 
 ### Changelogs
 
-goreleaser handles generating our changelog based on the commit subject of each
-commit.
+Changelog entries depend on commit subjects, which is why it is important that
+we encourage well written commit messages.
 
-Commits that start with `feat:` are grouped into a "Features" section, while
-those that start with `fix:` will be grouped into a "Bug fixes" section. Commits
-that begin with `chore:` or `docs:` will be excluded, and all others will be
-added to an "Others" section in the changelog.
+Based on the commit message, we group changes together like so:
 
-The [commit-message-check](./.github/workflows/commit-message-check.yaml)
-workflow enforces this format during pull requests. When pushing directly to
-master this will not prevent the commit from being pushed but the check will
-still fail.
+- `Features` groups all commits of type `feat`
+- `Bug Fixes` groups all commits of type `fix`
+- `Other` groups all other commits
+
+Note that the `chore` and `docs` commit types are ignored and will not show up
+in the changelog.
 
 For more details on commit message formatting see the
 [CONTRIBUTING](./CONTRIBUTING.md) doc.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -18,5 +18,10 @@ those that start with `fix:` will be grouped into a "Bug fixes" section. Commits
 that begin with `chore:` or `docs:` will be excluded, and all others will be
 added to an "Others" section in the changelog.
 
+The [commit-message-check](./.github/workflows/commit-message-check.yaml)
+workflow enforces this format during pull requests. When pushing directly to
+master this will not prevent the commit from being pushed but the check will
+still fail.
+
 For more details on commit message formatting see the
 [CONTRIBUTING](./CONTRIBUTING.md) doc.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -18,17 +18,5 @@ those that start with `fix:` will be grouped into a "Bug fixes" section. Commits
 that begin with `chore:` or `docs:` will be excluded, and all others will be
 added to an "Others" section in the changelog.
 
-When reviewing pull requests or committing code, it is strongly encouraged to
-use one of the aformentioned prefixes so that changelogs are nicely formatted
-and organized.
-
-## Commit Messages
-
-To maintain a tidy changelog on release, we should encourage the use of the
-following commit subject prefixes (see the Changelogs for details on how they
-are used)
-
-- `feat`: New features
-- `fix`: Bug fixes
-- `docs`: Usage documentation changes (ie. examples, README)
-- `chore`: Housekeeping taks that don't touch code or usage docs
+For more details on commit message formatting see the
+[CONTRIBUTING](./CONTRIBUTING.md) doc.


### PR DESCRIPTION
- Updates contributor docs to include details about our commit message convention
- Adds a GitHub workflow to ensure commit messages follow our convention.
- Updates maintainer docs to include information about how we release new versions.

Closes #129, closes #130 