### PR TITLE
fix: Resolve regression of BotInteractionMode

### DIFF
--- a/message_event.go
+++ b/message_event.go
@@ -108,13 +108,6 @@ func NewMessageEvent(slacker *Slacker, event interface{}, req *socketmode.Reques
 		return nil
 	}
 
-	// Filter out other bots. At the very least this is needed for MessageEvent
-	// to prevent the bot from self-triggering and causing loops. However better
-	// logic should be in place to prevent repeated self-triggering / bot-storms
-	// if we want to enable this later.
-	if messageEvent.IsBot() {
-		return nil
-	}
 	return messageEvent
 }
 


### PR DESCRIPTION
In commit d3d36ce8fb8cf7a9110034b02acf671ad6a37146 a regression was introduced that broke BotInteractionMode and instead ignored all bot messages.

Closes #135