### PR TITLE
feat: Add support for removal formatting from slack message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,43 @@ func (c *cmd) Interactive(slacker.InteractiveBotContext, *socketmode.Request, *s
 }
 ```
 
+## Example 20
+
+Cleanup font formatting symbols from message. Can be useful when someone copy-pastes code from any source to Slack.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/shomali11/slacker"
+)
+
+func main() {
+	// slacker.WithoutAllFormatting() can be used to disable all formatting including the code block
+	bot := slacker.NewClient(os.Getenv("SLACK_BOT_TOKEN"), os.Getenv("SLACK_APP_TOKEN"), slacker.WithoutFontFormatting())
+
+	definition := &slacker.CommandDefinition{
+		Handler: func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
+			response.Reply("pong")
+		},
+	}
+
+	bot.Command("ping", definition)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
 
 # Contributing / Submitting an Issue
 

--- a/defaults.go
+++ b/defaults.go
@@ -26,11 +26,27 @@ func WithBotInteractionMode(mode BotInteractionMode) ClientOption {
 	}
 }
 
+// WithoutFontFormatting disables font formatting in messages
+func WithoutFontFormatting() ClientOption {
+	return func(defaults *ClientDefaults) {
+		defaults.MessageWithoutFontFormatting = true
+	}
+}
+
+// WithoutAllFormatting disables font formatting in messages
+func WithoutAllFormatting() ClientOption {
+	return func(defaults *ClientDefaults) {
+		defaults.MessageWithoutAllFormatting = true
+	}
+}
+
 // ClientDefaults configuration
 type ClientDefaults struct {
-	APIURL  string
-	Debug   bool
-	BotMode BotInteractionMode
+	APIURL                       string
+	Debug                        bool
+	BotMode                      BotInteractionMode
+	MessageWithoutFontFormatting bool
+	MessageWithoutAllFormatting  bool
 }
 
 func newClientDefaults(options ...ClientOption) *ClientDefaults {

--- a/examples/20/example20.go
+++ b/examples/20/example20.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/shomali11/slacker"
+)
+
+func main() {
+	// slacker.WithoutAllFormatting() can be used to disable all formatting including the code block
+	bot := slacker.NewClient(os.Getenv("SLACK_BOT_TOKEN"), os.Getenv("SLACK_APP_TOKEN"), slacker.WithoutFontFormatting())
+
+	definition := &slacker.CommandDefinition{
+		Handler: func(botCtx slacker.BotContext, request slacker.Request, response slacker.ResponseWriter) {
+			response.Reply("pong")
+		},
+	}
+
+	bot.Command("ping", definition)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Create an additional functional option `WithoutFontFormatting()` and `WithoutAllFormatting()` that
may be passed into `NewClient(...)` that lets the user remove markdown formatting symbols from message. This
may be useful when bot user copies the part (or the whole command) from another source.

Previously, these commands did not work:
```
@qwerty *ping*
@qwerty create _192.168.1.1_
```