### PR TITLE
chore: Address goreleaser config deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,12 +7,13 @@ before:
     # You may remove this if you don't use go modules.
     - go mod tidy
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName}}_
+      {{ .Version }}_
+      {{ title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386"}}i386
+      {{- else}}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
archives.replacements was deprecated 2022-11-24 and expired recently on 2023-06-06, causing our builds to break.