### PR TITLE
feat: Handle more interaction type

### DIFF
--- a/examples/interaction-view/main.go
+++ b/examples/interaction-view/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/shomali11/slacker/v2"
+	"github.com/slack-go/slack"
+)
+
+var moodSurveyView = slack.ModalViewRequest{
+	Type:       "modal",
+	CallbackID: "mood-survey-callback-id",
+	Title: &slack.TextBlockObject{
+		Type: "plain_text",
+		Text: "Which mood are you in?",
+	},
+	Submit: &slack.TextBlockObject{
+		Type: "plain_text",
+		Text: "Submit",
+	},
+	NotifyOnClose: true,
+	Blocks: slack.Blocks{
+		BlockSet: []slack.Block{
+			&slack.InputBlock{
+				Type:    slack.MBTInput,
+				BlockID: "mood",
+				Label: &slack.TextBlockObject{
+					Type: "plain_text",
+					Text: "Mood",
+				},
+				Element: &slack.SelectBlockElement{
+					Type:     slack.OptTypeStatic,
+					ActionID: "mood",
+					Options: []*slack.OptionBlockObject{
+						{
+							Text: &slack.TextBlockObject{
+								Type: "plain_text",
+								Text: "Happy",
+							},
+							Value: "Happy",
+						},
+						{
+							Text: &slack.TextBlockObject{
+								Type: "plain_text",
+								Text: "Sad",
+							},
+							Value: "Sad",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// Implements a basic interactive command with modal view.
+func main() {
+	bot := slacker.NewClient(
+		os.Getenv("SLACK_BOT_TOKEN"),
+		os.Getenv("SLACK_APP_TOKEN"),
+		slacker.WithDebug(false),
+	)
+
+	bot.AddCommand(&slacker.CommandDefinition{
+		Command: "mood",
+		Handler: moodCmdHandler,
+	})
+
+	bot.AddInteraction(&slacker.InteractionDefinition{
+		CallbackID: "mood-survey-callback-id",
+		Handler:    moodViewHandler,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func moodCmdHandler(ctx *slacker.CommandContext) {
+	_, err := ctx.SlackClient().OpenView(
+		ctx.Event().Data.(*slack.SlashCommand).TriggerID,
+		moodSurveyView,
+	)
+	if err != nil {
+		log.Printf("ERROR openEscalationModal: %v", err)
+	}
+}
+
+func moodViewHandler(ctx *slacker.InteractionContext) {
+	switch ctx.Callback().Type {
+	case slack.InteractionTypeViewSubmission:
+		{
+			viewState := ctx.Callback().View.State.Values
+			fmt.Printf(
+				"Mood view submitted.\nMood: %s\n",
+				viewState["mood"]["mood"].SelectedOption.Value,
+			)
+		}
+	case slack.InteractionTypeViewClosed:
+		{
+			fmt.Print("Mood view closed.\n")
+		}
+	}
+}

--- a/interaction.go
+++ b/interaction.go
@@ -3,6 +3,7 @@ package slacker
 // InteractionDefinition structure contains definition of the bot interaction
 type InteractionDefinition struct {
 	BlockID     string
+	CallbackID  string
 	Middlewares []InteractionMiddlewareHandler
 	Handler     InteractionHandler
 }

--- a/slacker.go
+++ b/slacker.go
@@ -456,7 +456,7 @@ func (s *Slacker) handleInteractionEvent(ctx context.Context, callback *slack.In
 		}
 		s.logger.Debugf("unsupported block actions interaction type received %+v\n", callback)
 	case slack.InteractionTypeViewSubmission,
-		slack.InteractionTypeViewClosed,
+		slack.InteractionTypeViewClosed:
 		for _, interaction := range s.interactions {
 			definition := interaction.Definition()
 			if definition.CallbackID == callback.View.CallbackID {

--- a/slacker.go
+++ b/slacker.go
@@ -457,8 +457,6 @@ func (s *Slacker) handleInteractionEvent(ctx context.Context, callback *slack.In
 		s.logger.Debugf("unsupported block actions interaction type received %+v\n", callback)
 	case slack.InteractionTypeViewSubmission,
 		slack.InteractionTypeViewClosed,
-		slack.InteractionTypeShortcut,
-		slack.InteractionTypeMessageAction:
 		for _, interaction := range s.interactions {
 			definition := interaction.Definition()
 			if definition.CallbackID == callback.View.CallbackID {


### PR DESCRIPTION
A CallbackID field was added to the struct InteractionDefinition struct, to handle the following [interactions](https://api.slack.com/interactivity/handling):
- shortcut (not yet)
- message_actions (not yet)
- view_submission
- view_closed

I'm a junior dev in Golang so if you want to modify the PR don't hesitate I don't mind.