### PR TITLE
Adds support for block_suggestion handling through socket mode

### DIFF
--- a/executors.go
+++ b/executors.go
@@ -1,5 +1,7 @@
 package slacker
 
+import "github.com/slack-go/slack/socketmode"
+
 func executeCommand(ctx *CommandContext, handler CommandHandler, middlewares ...CommandMiddlewareHandler) {
 	if handler == nil {
 		return
@@ -22,6 +24,18 @@ func executeInteraction(ctx *InteractionContext, handler InteractionHandler, mid
 	}
 
 	handler(ctx)
+}
+
+func executeSuggestion(socketEvent socketmode.Event, ctx *InteractionContext, handler SuggestionHandler, middlewares ...SuggestionMiddlewareHandler) {
+	if handler == nil {
+		return
+	}
+
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+
+	handler(socketEvent, ctx)
 }
 
 func executeJob(ctx *JobContext, handler JobHandler, middlewares ...JobMiddlewareHandler) func() {

--- a/handler.go
+++ b/handler.go
@@ -1,5 +1,7 @@
 package slacker
 
+import "github.com/slack-go/slack/socketmode"
+
 // CommandMiddlewareHandler represents the command middleware handler function
 type CommandMiddlewareHandler func(CommandHandler) CommandHandler
 
@@ -9,8 +11,14 @@ type CommandHandler func(*CommandContext)
 // InteractionMiddlewareHandler represents the interaction middleware handler function
 type InteractionMiddlewareHandler func(InteractionHandler) InteractionHandler
 
+// SuggestionMiddlewareHandler represents the suggestion middleware handler function
+type SuggestionMiddlewareHandler func(SuggestionHandler) SuggestionHandler
+
 // InteractionHandler represents the interaction handler function
 type InteractionHandler func(*InteractionContext)
+
+// SuggestionHandler represents the interaction handler function for block_suggestion
+type SuggestionHandler func(sm socketmode.Event, ic *InteractionContext)
 
 // JobMiddlewareHandler represents the job middleware handler function
 type JobMiddlewareHandler func(JobHandler) JobHandler


### PR DESCRIPTION
In order to allow for external data source select dropdowns, we need to be able to handle the block_suggestion Interaction Type. This requires a response back to the Websocket in the form of slack.OptionsResponse{}. This payload needs to be sent back to Websocket with the socketmodeclient.Ack() func as the payload param. 

The current workflow is all Interactive Type events automatically get Ack'd and sent to their handler. I made an additional suggestionHandler workflow specifically for this block_suggestion event. Every other interaction type will be funneled through the original workflows.