### PR TITLE
feat: Add proper handling of block_suggestion Interaction events

### DIFF
--- a/executors.go
+++ b/executors.go
@@ -1,5 +1,7 @@
 package slacker
 
+import "github.com/slack-go/slack/socketmode"
+
 func executeCommand(ctx *CommandContext, handler CommandHandler, middlewares ...CommandMiddlewareHandler) {
 	if handler == nil {
 		return
@@ -22,6 +24,18 @@ func executeInteraction(ctx *InteractionContext, handler InteractionHandler, mid
 	}
 
 	handler(ctx)
+}
+
+func executeSuggestion(socketEvent socketmode.Event, ctx *InteractionContext, handler SuggestionHandler, middlewares ...SuggestionMiddlewareHandler) {
+	if handler == nil {
+		return
+	}
+
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+
+	handler(socketEvent, ctx)
 }
 
 func executeJob(ctx *JobContext, handler JobHandler, middlewares ...JobMiddlewareHandler) func() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shomali11/slacker/v2
+module github.com/0xArch3r/slacker
 
 go 1.18
 
@@ -6,10 +6,11 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shomali11/commander v0.0.0-20230730023802-0b64f620037d
 	github.com/shomali11/proper v0.0.0-20190608032528-6e70a05688e7
-	github.com/slack-go/slack v0.12.2
+	github.com/shomali11/slacker/v2 v2.0.0-alpha4
+	github.com/slack-go/slack v0.12.3
 )
 
 require (
 	github.com/gorilla/websocket v1.5.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/0xArch3r/slacker/v2
+module github.com/shomali11/slacker/v2
 
 go 1.18
 
@@ -6,11 +6,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shomali11/commander v0.0.0-20230730023802-0b64f620037d
 	github.com/shomali11/proper v0.0.0-20190608032528-6e70a05688e7
-	github.com/shomali11/slacker/v2 v2.0.0-alpha4
 	github.com/slack-go/slack v0.12.3
 )
 
-require (
-	github.com/gorilla/websocket v1.5.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require github.com/gorilla/websocket v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/0xArch3r/slacker
+module github.com/0xArch3r/slacker/v2
 
 go 1.18
 

--- a/go.sum
+++ b/go.sum
@@ -17,11 +17,14 @@ github.com/shomali11/commander v0.0.0-20230730023802-0b64f620037d/go.mod h1:bYyJ
 github.com/shomali11/proper v0.0.0-20180607004733-233a9a872c30/go.mod h1:O723XwIZBX3FR45rBic/Eyp/DKo/YtchYFURzpUWY2c=
 github.com/shomali11/proper v0.0.0-20190608032528-6e70a05688e7 h1:wAyBXFZOcLkbaoDlDbMpTCw9xy3yP2YJDMRrbTVuVKU=
 github.com/shomali11/proper v0.0.0-20190608032528-6e70a05688e7/go.mod h1:cg2VM85Y+0BcVSICzB+OafOlTcJ9QPbtF4qtuhuR/GA=
-github.com/slack-go/slack v0.12.2 h1:x3OppyMyGIbbiyFhsBmpf9pwkUzMhthJMRNmNlA4LaQ=
-github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
+github.com/shomali11/slacker/v2 v2.0.0-alpha4 h1:WxHHGDBg3L8apil+1loweUI50YmU+0rB3NcUDqeaN2w=
+github.com/shomali11/slacker/v2 v2.0.0-alpha4/go.mod h1:tjODmSr6C1BKHN1tA3f0aEjIaOXEAo7rhvPDXdjVeeo=
+github.com/slack-go/slack v0.12.3 h1:92/dfFU8Q5XP6Wp5rr5/T5JHLM5c5Smtn53fhToAP88=
+github.com/slack-go/slack v0.12.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -17,14 +17,9 @@ github.com/shomali11/commander v0.0.0-20230730023802-0b64f620037d/go.mod h1:bYyJ
 github.com/shomali11/proper v0.0.0-20180607004733-233a9a872c30/go.mod h1:O723XwIZBX3FR45rBic/Eyp/DKo/YtchYFURzpUWY2c=
 github.com/shomali11/proper v0.0.0-20190608032528-6e70a05688e7 h1:wAyBXFZOcLkbaoDlDbMpTCw9xy3yP2YJDMRrbTVuVKU=
 github.com/shomali11/proper v0.0.0-20190608032528-6e70a05688e7/go.mod h1:cg2VM85Y+0BcVSICzB+OafOlTcJ9QPbtF4qtuhuR/GA=
-github.com/shomali11/slacker/v2 v2.0.0-alpha4 h1:WxHHGDBg3L8apil+1loweUI50YmU+0rB3NcUDqeaN2w=
-github.com/shomali11/slacker/v2 v2.0.0-alpha4/go.mod h1:tjODmSr6C1BKHN1tA3f0aEjIaOXEAo7rhvPDXdjVeeo=
 github.com/slack-go/slack v0.12.3 h1:92/dfFU8Q5XP6Wp5rr5/T5JHLM5c5Smtn53fhToAP88=
 github.com/slack-go/slack v0.12.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/handler.go
+++ b/handler.go
@@ -1,5 +1,7 @@
 package slacker
 
+import "github.com/slack-go/slack/socketmode"
+
 // CommandMiddlewareHandler represents the command middleware handler function
 type CommandMiddlewareHandler func(CommandHandler) CommandHandler
 
@@ -9,8 +11,14 @@ type CommandHandler func(*CommandContext)
 // InteractionMiddlewareHandler represents the interaction middleware handler function
 type InteractionMiddlewareHandler func(InteractionHandler) InteractionHandler
 
+// SuggestionMiddlewareHandler represents the suggestion middleware handler function
+type SuggestionMiddlewareHandler func(SuggestionHandler) SuggestionHandler
+
 // InteractionHandler represents the interaction handler function
 type InteractionHandler func(*InteractionContext)
+
+// SuggestionHandler represents the interaction handler function for block_suggestion
+type SuggestionHandler func(sm socketmode.Event, ic *InteractionContext)
 
 // JobMiddlewareHandler represents the job middleware handler function
 type JobMiddlewareHandler func(JobHandler) JobHandler


### PR DESCRIPTION
Currently all Interaction events are .Ack() before they are passed to their respective handler functions. I broke that logic so that if the InteractionType is block_suggestion, we pass the socketevent and ctx thru a similar workflow but put the responsibility of the .Ack() on the person writing their handler func. This means that their backend can do whatever it needs to return the correct slack.OptionsResponse payload back to the websocket to allow for external data source menu drop-downs to function properly.

Adds Suggestion Handler workflow to allow the proper handling of block_suggestion