### PR TITLE
feat: Handle more interaction types

### DIFF
--- a/examples/interaction-middleware/main.go
+++ b/examples/interaction-middleware/main.go
@@ -20,8 +20,9 @@ func main() {
 
 	bot.AddInteractionMiddleware(LoggingInteractionMiddleware())
 	bot.AddInteraction(&slacker.InteractionDefinition{
-		BlockID: "mood",
-		Handler: slackerInteractive,
+		InteractionID: "mood",
+		Handler:       slackerInteractive,
+		Type:          slack.InteractionTypeBlockActions,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -68,7 +69,7 @@ func LoggingInteractionMiddleware() slacker.InteractionMiddlewareHandler {
 			ctx.Logger().Infof(
 				"%s initiated \"%s\" with action \"%v\" in channel %s\n",
 				ctx.Callback().User.ID,
-				ctx.Definition().BlockID,
+				ctx.Definition().InteractionID,
 				ctx.Callback().ActionCallback.BlockActions[0].ActionID,
 				ctx.Callback().Channel.ID,
 			)

--- a/examples/interaction-shortcut/main.go
+++ b/examples/interaction-shortcut/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/shomali11/slacker/v2"
+	"github.com/slack-go/slack"
+)
+
+// Implements a basic interactive command with modal view.
+
+func main() {
+	bot := slacker.NewClient(
+		os.Getenv("SLACK_BOT_TOKEN"),
+		os.Getenv("SLACK_APP_TOKEN"),
+		slacker.WithDebug(false),
+	)
+
+	bot.AddInteraction(&slacker.InteractionDefinition{
+		InteractionID: "mood-survey-message-shortcut-callback-id",
+		Handler:       moodShortcutHandler,
+		Type:          slack.InteractionTypeMessageAction,
+	})
+
+	bot.AddInteraction(&slacker.InteractionDefinition{
+		InteractionID: "mood-survey-global-shortcut-callback-id",
+		Handler:       moodShortcutHandler,
+		Type:          slack.InteractionTypeShortcut,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func moodShortcutHandler(ctx *slacker.InteractionContext) {
+	switch ctx.Callback().Type {
+	case slack.InteractionTypeMessageAction:
+		{
+			fmt.Print("Message shortcut.\n")
+		}
+	case slack.InteractionTypeShortcut:
+		{
+			fmt.Print("Global shortcut.\n")
+		}
+	}
+}

--- a/examples/interaction-view/main.go
+++ b/examples/interaction-view/main.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/shomali11/slacker/v2"
+	"github.com/slack-go/slack"
+)
+
+var moodSurveyView = slack.ModalViewRequest{
+	Type:       "modal",
+	CallbackID: "mood-survey-callback-id",
+	Title: &slack.TextBlockObject{
+		Type: "plain_text",
+		Text: "Which mood are you in?",
+	},
+	Submit: &slack.TextBlockObject{
+		Type: "plain_text",
+		Text: "Submit",
+	},
+	NotifyOnClose: true,
+	Blocks: slack.Blocks{
+		BlockSet: []slack.Block{
+			&slack.InputBlock{
+				Type:    slack.MBTInput,
+				BlockID: "mood",
+				Label: &slack.TextBlockObject{
+					Type: "plain_text",
+					Text: "Mood",
+				},
+				Element: &slack.SelectBlockElement{
+					Type:     slack.OptTypeStatic,
+					ActionID: "mood",
+					Options: []*slack.OptionBlockObject{
+						{
+							Text: &slack.TextBlockObject{
+								Type: "plain_text",
+								Text: "Happy",
+							},
+							Value: "Happy",
+						},
+						{
+							Text: &slack.TextBlockObject{
+								Type: "plain_text",
+								Text: "Sad",
+							},
+							Value: "Sad",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+// Implements a basic interactive command with modal view.
+func main() {
+	bot := slacker.NewClient(
+		os.Getenv("SLACK_BOT_TOKEN"),
+		os.Getenv("SLACK_APP_TOKEN"),
+		slacker.WithDebug(false),
+	)
+
+	bot.AddCommand(&slacker.CommandDefinition{
+		Command: "mood",
+		Handler: moodCmdHandler,
+	})
+
+	bot.AddInteraction(&slacker.InteractionDefinition{
+		InteractionID: "mood-survey-callback-id",
+		Handler:       moodViewHandler,
+		Type:          slack.InteractionTypeViewSubmission,
+	})
+
+	bot.AddInteraction(&slacker.InteractionDefinition{
+		InteractionID: "mood-survey-callback-id",
+		Handler:       moodViewHandler,
+		Type:          slack.InteractionTypeViewClosed,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func moodCmdHandler(ctx *slacker.CommandContext) {
+	_, err := ctx.SlackClient().OpenView(
+		ctx.Event().Data.(*slack.SlashCommand).TriggerID,
+		moodSurveyView,
+	)
+	if err != nil {
+		log.Printf("ERROR openEscalationModal: %v", err)
+	}
+}
+
+func moodViewHandler(ctx *slacker.InteractionContext) {
+	switch ctx.Callback().Type {
+	case slack.InteractionTypeViewSubmission:
+		{
+			viewState := ctx.Callback().View.State.Values
+			fmt.Printf(
+				"Mood view submitted.\nMood: %s\n",
+				viewState["mood"]["mood"].SelectedOption.Value,
+			)
+		}
+	case slack.InteractionTypeViewClosed:
+		{
+			fmt.Print("Mood view closed.\n")
+		}
+	}
+}

--- a/examples/interaction-view/main.go
+++ b/examples/interaction-view/main.go
@@ -96,7 +96,7 @@ func moodCmdHandler(ctx *slacker.CommandContext) {
 		moodSurveyView,
 	)
 	if err != nil {
-		log.Printf("ERROR openEscalationModal: %v", err)
+		fmt.Printf("ERROR openEscalationModal: %v\n", err)
 	}
 }
 
@@ -111,8 +111,6 @@ func moodViewHandler(ctx *slacker.InteractionContext) {
 			)
 		}
 	case slack.InteractionTypeViewClosed:
-		{
-			fmt.Print("Mood view closed.\n")
-		}
+		fmt.Print("Mood view closed.\n")
 	}
 }

--- a/examples/interaction/main.go
+++ b/examples/interaction/main.go
@@ -19,8 +19,9 @@ func main() {
 	})
 
 	bot.AddInteraction(&slacker.InteractionDefinition{
-		BlockID: "mood",
-		Handler: slackerInteractive,
+		InteractionID: "mood",
+		Handler:       slackerInteractive,
+		Type:          slack.InteractionTypeBlockActions,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/interaction.go
+++ b/interaction.go
@@ -1,10 +1,13 @@
 package slacker
 
+import "github.com/slack-go/slack"
+
 // InteractionDefinition structure contains definition of the bot interaction
 type InteractionDefinition struct {
-	BlockID     string
-	Middlewares []InteractionMiddlewareHandler
-	Handler     InteractionHandler
+	InteractionID string
+	Middlewares   []InteractionMiddlewareHandler
+	Handler       InteractionHandler
+	Type          slack.InteractionType
 }
 
 // newInteraction creates a new bot interaction object


### PR DESCRIPTION
  Convert BlockID to InteractionID field into the InteractionDefinition struct,
and add the necessary dispatch mechanisms to handle the following interactions:
- shortcut
- message_actions
- view_submission
- view_closed