### PR TITLE
feat: Adds support for properly handling block_suggestion events

### DIFF
--- a/executors.go
+++ b/executors.go
@@ -1,5 +1,7 @@
 package slacker
 
+import "github.com/slack-go/slack"
+
 func executeCommand(ctx *CommandContext, handler CommandHandler, middlewares ...CommandMiddlewareHandler) {
 	if handler == nil {
 		return
@@ -22,6 +24,18 @@ func executeInteraction(ctx *InteractionContext, handler InteractionHandler, mid
 	}
 
 	handler(ctx)
+}
+
+func executeSuggestion(ctx *InteractionContext, handler SuggestionHandler, middlewares ...SuggestionMiddlewareHandler) slack.OptionsResponse {
+	if handler == nil {
+		return slack.OptionsResponse{}
+	}
+
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+
+	return handler(ctx)
 }
 
 func executeJob(ctx *JobContext, handler JobHandler, middlewares ...JobMiddlewareHandler) func() {

--- a/handler.go
+++ b/handler.go
@@ -1,5 +1,9 @@
 package slacker
 
+import (
+	"github.com/slack-go/slack"
+)
+
 // CommandMiddlewareHandler represents the command middleware handler function
 type CommandMiddlewareHandler func(CommandHandler) CommandHandler
 
@@ -11,6 +15,12 @@ type InteractionMiddlewareHandler func(InteractionHandler) InteractionHandler
 
 // InteractionHandler represents the interaction handler function
 type InteractionHandler func(*InteractionContext)
+
+// SuggestionMiddlewareHandler represents the suggestion middleware handler function
+type SuggestionMiddlewareHandler func(SuggestionHandler) SuggestionHandler
+
+// SuggestionHandler represents the interaction handler function for block_suggestion
+type SuggestionHandler func(*InteractionContext) slack.OptionsResponse
 
 // JobMiddlewareHandler represents the job middleware handler function
 type JobMiddlewareHandler func(JobHandler) JobHandler


### PR DESCRIPTION
Create a block_suggestion handling workflow that mimics the current InteractionHandler workflows. Add suggestionHandlers slice to slaccker struct. Adds SuggestionHandler and SuggetionHandlerMiddleware functions. Adds logic in the main slacker.Listen func to switch between generic Interactions and block_suggestion interaction types